### PR TITLE
Add model tests for node contributors

### DIFF
--- a/osf_models_tests/test_node.py
+++ b/osf_models_tests/test_node.py
@@ -417,29 +417,6 @@ class TestContributorMethods:
         assert node.get_permissions(user2) == []
         assert node.logs.latest().action == 'contributor_removed'
 
-    def test_move_contributor(self, user, node, auth):
-        user1 = UserFactory()
-        user2 = UserFactory()
-        node.add_contributors(
-            [
-                {'user': user1, 'permissions': ['read', 'write'], 'visible': True},
-                {'user': user2, 'permissions': ['read', 'write'], 'visible': True}
-            ],
-            auth=auth
-        )
-
-        user_contrib_id = node.contributor_set.get(user=user).id
-        user1_contrib_id = node.contributor_set.get(user=user1).id
-        user2_contrib_id = node.contributor_set.get(user=user2).id
-
-        old_order = [user_contrib_id, user1_contrib_id, user2_contrib_id]
-        assert list(node.get_contributor_order()) == old_order
-
-        node.move_contributor(user=user2, auth=auth, index=0, save=True)
-
-        new_order = [user2_contrib_id, user_contrib_id, user1_contrib_id]
-        assert list(node.get_contributor_order()) == new_order
-
 
     def test_replace_contributor(self, node):
         contrib = UserFactory()
@@ -1528,6 +1505,7 @@ class TestAlternativeCitationMethods:
             'name': name, 'text': text
         }
 
+
 class TestContributorOrdering:
 
     def test_can_get_contributor_order(self, node):
@@ -1546,6 +1524,30 @@ class TestContributorOrdering:
         node.set_contributor_order([contrib1.id, contrib2.id, creator_contrib.id])
         assert list(node.get_contributor_order()) == [contrib1.id, contrib2.id, creator_contrib.id]
         assert list(node.contributors.all()) == [user1, user2, node.creator]
+
+    def test_move_contributor(self, user, node, auth):
+        user1 = UserFactory()
+        user2 = UserFactory()
+        node.add_contributors(
+            [
+                {'user': user1, 'permissions': ['read', 'write'], 'visible': True},
+                {'user': user2, 'permissions': ['read', 'write'], 'visible': True}
+            ],
+            auth=auth
+        )
+
+        user_contrib_id = node.contributor_set.get(user=user).id
+        user1_contrib_id = node.contributor_set.get(user=user1).id
+        user2_contrib_id = node.contributor_set.get(user=user2).id
+
+        old_order = [user_contrib_id, user1_contrib_id, user2_contrib_id]
+        assert list(node.get_contributor_order()) == old_order
+
+        node.move_contributor(user=user2, auth=auth, index=0, save=True)
+
+        new_order = [user2_contrib_id, user_contrib_id, user1_contrib_id]
+        assert list(node.get_contributor_order()) == new_order
+
 
 class TestNodeOrdering:
 

--- a/osf_models_tests/test_node.py
+++ b/osf_models_tests/test_node.py
@@ -401,7 +401,7 @@ class TestContributorMethods:
         node.add_contributors(
             [
                 {'user': user1, 'permissions': ['read', 'write'], 'visible': True},
-                {'user': user2, 'permissions': ['read', 'write'], 'visible': False}
+                {'user': user2, 'permissions': ['read', 'write'], 'visible': True}
             ],
             auth=auth
         )
@@ -416,6 +416,29 @@ class TestContributorMethods:
         assert node.get_permissions(user1) == []
         assert node.get_permissions(user2) == []
         assert node.logs.latest().action == 'contributor_removed'
+
+    def test_move_contributor(self, user, node, auth):
+        user1 = UserFactory()
+        user2 = UserFactory()
+        node.add_contributors(
+            [
+                {'user': user1, 'permissions': ['read', 'write'], 'visible': True},
+                {'user': user2, 'permissions': ['read', 'write'], 'visible': True}
+            ],
+            auth=auth
+        )
+
+        user_contrib_id = node.contributor_set.get(user=user).id
+        user1_contrib_id = node.contributor_set.get(user=user1).id
+        user2_contrib_id = node.contributor_set.get(user=user2).id
+
+        old_order = [user_contrib_id, user1_contrib_id, user2_contrib_id]
+        assert list(node.get_contributor_order()) == old_order
+
+        node.move_contributor(user=user2, auth=auth, index=0, save=True)
+
+        new_order = [user2_contrib_id, user_contrib_id, user1_contrib_id]
+        assert list(node.get_contributor_order()) == new_order
 
 
     def test_replace_contributor(self, node):

--- a/osf_models_tests/test_node.py
+++ b/osf_models_tests/test_node.py
@@ -381,6 +381,21 @@ class TestContributorMethods:
         assert node2.has_permission(read, 'write') is False
         assert node2.has_permission(admin, 'admin') is True
 
+    def test_remove_contributor(self, node, auth):
+        # A user is added as a contributor
+        user2 = UserFactory()
+        node.add_contributor(contributor=user2, auth=auth, save=True)
+        assert user2 in node.contributors
+        # The user is removed
+        node.remove_contributor(auth=auth, contributor=user2)
+        node.reload()
+
+        assert user2 not in node.contributors
+        assert node.get_permissions(user2) == []
+        assert node.logs.latest().action == 'contributor_removed'
+        assert node.logs.latest().params['contributors'] == [user2._id]
+
+
     def test_replace_contributor(self, node):
         contrib = UserFactory()
         node.add_contributor(contrib, auth=Auth(node.creator))

--- a/osf_models_tests/test_node.py
+++ b/osf_models_tests/test_node.py
@@ -395,6 +395,28 @@ class TestContributorMethods:
         assert node.logs.latest().action == 'contributor_removed'
         assert node.logs.latest().params['contributors'] == [user2._id]
 
+    def test_remove_contributors(self, node, auth):
+        user1 = UserFactory()
+        user2 = UserFactory()
+        node.add_contributors(
+            [
+                {'user': user1, 'permissions': ['read', 'write'], 'visible': True},
+                {'user': user2, 'permissions': ['read', 'write'], 'visible': False}
+            ],
+            auth=auth
+        )
+        assert user1 in node.contributors
+        assert user2 in node.contributors
+
+        node.remove_contributors(auth=auth, contributors=[user1, user2], save=True)
+        node.reload()
+
+        assert user1 not in node.contributors
+        assert user2 not in node.contributors
+        assert node.get_permissions(user1) == []
+        assert node.get_permissions(user2) == []
+        assert node.logs.latest().action == 'contributor_removed'
+
 
     def test_replace_contributor(self, node):
         contrib = UserFactory()

--- a/osf_models_tests/test_node.py
+++ b/osf_models_tests/test_node.py
@@ -438,6 +438,23 @@ class TestContributorMethods:
             contrib.unclaimed_records.keys()
         )
 
+class TestContributorProperties:
+
+    def test_admin_contributor_ids(self, user, node, auth):
+        user1 = UserFactory()
+        user2 = UserFactory()
+        node.add_contributors(
+            [
+                {'user': user1, 'permissions': ['read', 'write', 'admin'], 'visible': True},
+                {'user': user2, 'permissions': ['read', 'write'], 'visible': True}
+            ],
+            auth=auth
+        )
+
+        assert user.guid.guid in node.admin_contributor_ids
+        assert user1.guid.guid in node.admin_contributor_ids
+        assert user2.guid.guid not in node.admin_contributor_ids
+
 
 class TestContributorAddedSignal:
 
@@ -1569,6 +1586,7 @@ class TestNodeOrdering:
     def test_can_set_node_order(self, project, children):
         project.set_abstractnode_order([children[2].pk, children[1].pk, children[0].pk])
         assert list(project.nodes.all()) == [children[2], children[1], children[0]]
+
 
 def test_templated_list(node):
     templated1, templated2 = ProjectFactory(template_node=node), NodeFactory(template_node=node)


### PR DESCRIPTION
# Purpose

Add some model tests for contributors for the new django osf-models!

# Changes
Tests for:
- remove contributor
- remove contributors
- move contributor
- admin_contributor_ids

# Ticket
https://github.com/CenterForOpenScience/osf-models/issues/124