### PR TITLE
[Feature] CAS returns User's PK instead of GUID

### DIFF
--- a/framework/auth/cas.py
+++ b/framework/auth/cas.py
@@ -301,7 +301,7 @@ def get_user_from_cas_resp(cas_resp):
     """
 
     if cas_resp.user:
-        user = User.load(cas_resp.user)
+        user = User.objects.get(pk=cas_resp.user)
         # cas returns a valid OSF user id
         if user:
             return user, None, 'authenticate'


### PR DESCRIPTION
CAS now returns User PK in `get_user_from_cas_resp` called by `make_response_from_ticket` in `framework/auth/cas.py`. Local manual functionality test passed.

Related CAS [commit](https://github.com/CenterForOpenScience/cas-overlay/pull/23/commits/7865e0711fbbca1657a1ab5453685e53c696d428) and code. Note that the PK is converted from `Integer` to `String`:
```java
return createHandlerResult(
    credential,
    this.principalFactory.createPrincipal(user.getId().toString(), attributes),
    null
);
```

No side effect since this is only entry point where CAS send authenticated user info to OSF.