### PR TITLE
Port registrations tests to osf-models tests in test_registrations and test_sanctions

### DIFF
--- a/osf_models_tests/test_registrations.py
+++ b/osf_models_tests/test_registrations.py
@@ -460,20 +460,15 @@ class TestDraftRegistrations:
         assert draft.registration_schema == schema
         assert draft.registration_metadata == data
 
-    @pytest.mark.skip('Need to figure out registration error')
-    @mock.patch('osf_models.models.node.AbstractNode.register_node')
-    def test_register(self, mock_register_node):
+    @mock.patch('framework.celery_tasks.handlers.enqueue_task')
+    def test_register(self, mock_enquque):
         user = factories.UserFactory()
         auth = Auth(user)
         project = factories.ProjectFactory(creator=user)
         draft = factories.DraftRegistrationFactory(branched_from=project)
-
-        draft.register(auth)  # throws error - DraftRegistration.registered_node must be a "Registration" instance.
-        mock_register_node.assert_called_with(
-            schema=draft.registration_schema,
-            auth=auth,
-            data=draft.registration_metadata,
-        )
+        assert not draft.registered_node
+        draft.register(auth)
+        assert draft.registered_node
 
     def test_update_metadata_tracks_changes(self, project):
         draft = factories.DraftRegistrationFactory(branched_from=project)

--- a/osf_models_tests/test_registrations.py
+++ b/osf_models_tests/test_registrations.py
@@ -16,13 +16,16 @@ from .factories import get_default_metaschema
 
 pytestmark = pytest.mark.django_db
 
+
 @pytest.fixture(autouse=True)
 def _ensure_schemas():
     return ensure_schemas()
 
+
 @pytest.fixture()
 def user():
     return factories.UserFactory()
+
 
 @pytest.fixture()
 def project(user, auth, fake):
@@ -30,9 +33,11 @@ def project(user, auth, fake):
     ret.add_tag(fake.word(), auth=auth)
     return ret
 
+
 @pytest.fixture()
 def auth(user):
     return Auth(user)
+
 
 # copied from tests/test_models.py
 def test_factory(user, project):
@@ -61,6 +66,7 @@ def test_factory(user, project):
         registration2.registered_meta[get_default_metaschema()._id] ==
         {'some': 'data'}
     )
+
 
 # copied from tests/test_models.py
 class TestRegisterNode:
@@ -265,15 +271,15 @@ class TestRegisterNode:
         wiki = factories.NodeWikiFactory(node=project)
         current_wiki = factories.NodeWikiFactory(node=project, version=2)
         registration = project.register_node(get_default_metaschema(), Auth(self.user), '', None)
-        assert_equal(self.registration.wiki_private_uuids, {})
+        assert self.registration.wiki_private_uuids == {}
 
         registration_wiki_current = NodeWikiPage.load(registration.wiki_pages_current[current_wiki.page_name])
-        assert_equal(registration_wiki_current.node, registration)
-        assert_not_equal(registration_wiki_current._id, current_wiki._id)
+        assert registration_wiki_current.node == registration
+        assert registration_wiki_current._id != current_wiki._id
 
         registration_wiki_version = NodeWikiPage.load(registration.wiki_pages_versions[wiki.page_name][0])
-        assert_equal(registration_wiki_version.node, registration)
-        assert_not_equal(registration_wiki_version._id, wiki._id)
+        assert registration_wiki_version.node == registration
+        assert registration_wiki_version._id != wiki._id
 
     def test_legacy_private_registrations_can_be_made_public(self, registration, auth):
         registration.is_public = False

--- a/osf_models_tests/test_registrations.py
+++ b/osf_models_tests/test_registrations.py
@@ -460,9 +460,8 @@ class TestDraftRegistrations:
         assert draft.registration_schema == schema
         assert draft.registration_metadata == data
 
+    @mock.patch('website.settings.ENABLE_ARCHIVER', False)
     def test_register(self):
-        previous_archiver_settings = settings.ENABLE_ARCHIVER
-        settings.ENABLE_ARCHIVER = False
         user = factories.UserFactory()
         auth = Auth(user)
         project = factories.ProjectFactory(creator=user)
@@ -470,7 +469,6 @@ class TestDraftRegistrations:
         assert not draft.registered_node
         draft.register(auth)
         assert draft.registered_node
-        settings.ENABLE_ARCHIVER = previous_archiver_settings
 
     def test_update_metadata_tracks_changes(self, project):
         draft = factories.DraftRegistrationFactory(branched_from=project)

--- a/osf_models_tests/test_registrations.py
+++ b/osf_models_tests/test_registrations.py
@@ -460,8 +460,9 @@ class TestDraftRegistrations:
         assert draft.registration_schema == schema
         assert draft.registration_metadata == data
 
-    @mock.patch('framework.celery_tasks.handlers.enqueue_task')
-    def test_register(self, mock_enquque):
+    def test_register(self):
+        previous_archiver_settings = settings.ENABLE_ARCHIVER
+        settings.ENABLE_ARCHIVER = False
         user = factories.UserFactory()
         auth = Auth(user)
         project = factories.ProjectFactory(creator=user)
@@ -469,6 +470,7 @@ class TestDraftRegistrations:
         assert not draft.registered_node
         draft.register(auth)
         assert draft.registered_node
+        settings.ENABLE_ARCHIVER = previous_archiver_settings
 
     def test_update_metadata_tracks_changes(self, project):
         draft = factories.DraftRegistrationFactory(branched_from=project)

--- a/osf_models_tests/test_registrations.py
+++ b/osf_models_tests/test_registrations.py
@@ -4,7 +4,7 @@ import datetime
 
 from django.utils import timezone
 from framework.auth.core import Auth
-from osf_models.models import Node, Registration, Sanction, MetaSchema
+from osf_models.models import Node, Registration, Sanction, MetaSchema, DraftRegistrationApproval
 from osf_models.modm_compat import Q
 
 from website import settings
@@ -554,3 +554,88 @@ class TestDraftRegistrations:
         draft.update_metadata(new_data)
         draft.save()
         assert draft.registration_metadata['foo']['comments'] == comments
+
+
+class TestDraftRegistrationApprovals:
+
+    @mock.patch('framework.celery_tasks.handlers.enqueue_task')
+    def test_on_complete_immediate_creates_registration_for_draft_initiator(self, mock_enquque):
+        user = factories.UserFactory()
+        approval = DraftRegistrationApproval(
+            initiated_by=user,
+            meta={
+                'registration_choice': 'immediate'
+            }
+        )
+        approval.save()
+
+        approval._on_complete(user)
+
+        project = factories.ProjectFactory(creator=user)
+        draft = factories.DraftRegistrationFactory(branched_from=project)
+        draft.registration_schema = MetaSchema.find_one(
+            Q('name', 'eq', 'Prereg Challenge') &
+            Q('schema_version', 'eq', 2)
+        )
+        draft.approval = approval
+        draft.save()
+
+        registered_node = draft.registered_node
+        assert registered_node is not None
+        assert registered_node.is_pending_registration
+        assert registered_node.registered_user == draft.initiator
+
+    @mock.patch('framework.celery_tasks.handlers.enqueue_task')
+    def test_on_complete_embargo_creates_registration_for_draft_initiator(self, mock_enquque):
+        user = factories.UserFactory()
+        end_date = datetime.datetime.now() + datetime.timedelta(days=366)  # <- leap year
+        approval = DraftRegistrationApproval(
+            initiated_by=user,
+            meta={
+                'registration_choice': 'embargo',
+                'embargo_end_date': end_date.isoformat()
+            }
+        )
+        approval.save()
+        project = factories.ProjectFactory(creator=user)
+        draft = factories.DraftRegistrationFactory(branched_from=project)
+        draft.registration_schema = MetaSchema.find_one(
+            Q('name', 'eq', 'Prereg Challenge') &
+            Q('schema_version', 'eq', 2)
+        )
+        draft.approval = approval
+        draft.save()
+
+        approval._on_complete(user)
+        registered_node = draft.registered_node
+        assert registered_node is not None
+        assert registered_node.is_pending_embargo
+        assert registered_node.registered_user == self.draft.initiator
+
+    def test_approval_requires_only_a_single_authorizer(self):
+        approval = DraftRegistrationApproval(
+            initiated_by=user,
+            meta={
+                'registration_choice': 'immediate',
+            }
+        )
+        approval.save()
+        with mock.patch.object(approval, '_on_complete') as mock_on_complete:
+            authorizer1 = factories.AuthUserFactory()
+            authorizer1.add_system_tag(settings.PREREG_ADMIN_TAG)
+            approval.approve(authorizer1)
+            assert mock_on_complete.called
+            assert approval.is_approved
+
+    @mock.patch('website.mails.send_mail')
+    def test_on_reject(self, mock_send_mail):
+        user = factories.UserFactory()
+        approval = DraftRegistrationApproval(
+            initiated_by=user,
+            meta={
+                'registration_choice': 'immediate'
+            }
+        )
+        approval._on_reject(user)
+        assert self.approval.meta == {}
+        assert mock_send_mail.call_count == 1

--- a/osf_models_tests/test_sanctions.py
+++ b/osf_models_tests/test_sanctions.py
@@ -118,6 +118,7 @@ class TestDraftRegistrationApprovals:
         )
         approval.save()
         project = factories.ProjectFactory(creator=user)
+        ensure_schemas()
         registration_schema = MetaSchema.find_one(
             Q('name', 'eq', 'Prereg Challenge') &
             Q('schema_version', 'eq', 2)
@@ -130,10 +131,11 @@ class TestDraftRegistrationApprovals:
         draft.save()
 
         approval._on_complete(user)
+        draft.reload()
         registered_node = draft.registered_node
         assert registered_node is not None
         assert registered_node.is_pending_embargo
-        assert registered_node.registered_user == self.draft.initiator
+        assert registered_node.registered_user == draft.initiator
 
     def test_approval_requires_only_a_single_authorizer(self):
         approval = DraftRegistrationApproval(

--- a/osf_models_tests/test_sanctions.py
+++ b/osf_models_tests/test_sanctions.py
@@ -2,14 +2,19 @@
 """Tests ported from tests/test_sanctions.py."""
 import mock
 import pytest
+import datetime
 
+from osf_models.modm_compat import Q
+from osf_models import DraftRegistrationApproval, MetaSchema
 from osf_models_tests import factories
 from osf_models_tests.utils import mock_archive
 
 from framework.auth import Auth
 
+from website import settings
 from website.exceptions import NodeStateError
 from website.project.model import NodeLog
+
 
 @pytest.mark.django_db
 class TestRegistrationApprovalHooks:
@@ -24,6 +29,7 @@ class TestRegistrationApprovalHooks:
         assert registration.registration_approval.is_pending_approval is True  # sanity check
         registration.registration_approval._on_complete(None)
         assert registration.registration_approval.is_pending_approval is False
+
 
 @pytest.mark.django_db
 class TestNodeEmbargoTerminations:
@@ -65,3 +71,85 @@ class TestNodeEmbargoTerminations:
         last_log = node.logs.first()
         assert last_log.action == NodeLog.EMBARGO_TERMINATED
         assert last_log.user is None
+
+
+class TestDraftRegistrationApprovals:
+
+    @mock.patch('framework.celery_tasks.handlers.enqueue_task')
+    def test_on_complete_immediate_creates_registration_for_draft_initiator(self, mock_enquque):
+        user = factories.UserFactory()
+        approval = DraftRegistrationApproval(
+            initiated_by=user,
+            meta={
+                'registration_choice': 'immediate'
+            }
+        )
+        approval.save()
+
+        approval._on_complete(user)
+
+        project = factories.ProjectFactory(creator=user)
+        draft = factories.DraftRegistrationFactory(branched_from=project)
+        draft.registration_schema = MetaSchema.find_one(
+            Q('name', 'eq', 'Prereg Challenge') &
+            Q('schema_version', 'eq', 2)
+        )
+        draft.approval = approval
+        draft.save()
+
+        registered_node = draft.registered_node
+        assert registered_node is not None
+        assert registered_node.is_pending_registration
+        assert registered_node.registered_user == draft.initiator
+
+    @mock.patch('framework.celery_tasks.handlers.enqueue_task')
+    def test_on_complete_embargo_creates_registration_for_draft_initiator(self, mock_enquque):
+        user = factories.UserFactory()
+        end_date = datetime.datetime.now() + datetime.timedelta(days=366)  # <- leap year
+        approval = DraftRegistrationApproval(
+            meta={
+                'registration_choice': 'embargo',
+                'embargo_end_date': end_date.isoformat()
+            }
+        )
+        approval.save()
+        project = factories.ProjectFactory(creator=user)
+        draft = factories.DraftRegistrationFactory(branched_from=project)
+        draft.registration_schema = MetaSchema.find_one(
+            Q('name', 'eq', 'Prereg Challenge') &
+            Q('schema_version', 'eq', 2)
+        )
+        draft.approval = approval
+        draft.save()
+
+        approval._on_complete(user)
+        registered_node = draft.registered_node
+        assert registered_node is not None
+        assert registered_node.is_pending_embargo
+        assert registered_node.registered_user == self.draft.initiator
+
+    def test_approval_requires_only_a_single_authorizer(self):
+        approval = DraftRegistrationApproval(
+            meta={
+                'registration_choice': 'immediate',
+            }
+        )
+        approval.save()
+        with mock.patch.object(approval, '_on_complete') as mock_on_complete:
+            authorizer1 = factories.AuthUserFactory()
+            authorizer1.add_system_tag(settings.PREREG_ADMIN_TAG)
+            approval.approve(authorizer1)
+            assert mock_on_complete.called
+            assert approval.is_approved
+
+    @mock.patch('website.mails.send_mail')
+    def test_on_reject(self, mock_send_mail):
+        user = factories.UserFactory()
+        approval = DraftRegistrationApproval(
+            meta={
+                'registration_choice': 'immediate'
+            }
+        )
+        approval._on_reject(user)
+        assert approval.meta == {}
+        assert mock_send_mail.call_count == 1

--- a/osf_models_tests/test_sanctions.py
+++ b/osf_models_tests/test_sanctions.py
@@ -157,6 +157,19 @@ class TestDraftRegistrationApprovals:
                 'registration_choice': 'immediate'
             }
         )
+        approval.save()
+        project = factories.ProjectFactory(creator=user)
+        ensure_schemas()
+        registration_schema = MetaSchema.find_one(
+            Q('name', 'eq', 'Prereg Challenge') &
+            Q('schema_version', 'eq', 2)
+        )
+        draft = factories.DraftRegistrationFactory(
+            branched_from=project,
+            registration_schema=registration_schema,
+        )
+        draft.approval = approval
+        draft.save()
         approval._on_reject(user)
         assert approval.meta == {}
         assert mock_send_mail.call_count == 1

--- a/osf_models_tests/test_sanctions.py
+++ b/osf_models_tests/test_sanctions.py
@@ -96,15 +96,12 @@ class TestDraftRegistrationApprovals:
             }
         )
         approval.save()
-        approval.reload()
         draft.approval = approval
         draft.save()
-        draft.reload()
-
-        # MetaSchema.remove()
         approval._on_complete(user)
-
+        draft.reload()
         registered_node = draft.registered_node
+
         assert registered_node is not None
         assert registered_node.is_pending_registration
         assert registered_node.registered_user == draft.initiator


### PR DESCRIPTION
# Purpose
Port tests from `tests/test_registrations/test_models.py` into relevant places in `osf_models_tests/test_registrations.py` and `osf_models_tests/test_sanctions.py`

# Changes
- Most tests remained functionally the same
- One that changed was `test_register` -- 
    [the original test_register](https://github.com/CenterForOpenScience/osf.io/blob/develop/tests/test_registrations/test_models.py#L54) used mock for the `register_node` method and then assert it was called with relevant arguments. I had trouble getting `osf-models` to play nicely with the mocked function, so switched to mocking the celery portion and checking to see if the registration was present [in the new implementation](https://github.com/sloria/osf.io/compare/feature/postgres...erinspace:feature/registration_tests?expand=1#diff-6aa278291bf038fd2eb220aca08ab5c2R464)

# Side Effects
Should be ok!

# Ticket
https://github.com/CenterForOpenScience/osf-models/issues/125